### PR TITLE
Adding history_size attribute to control conversation size to avoid 4…

### DIFF
--- a/mem0/dynamodb/README.md
+++ b/mem0/dynamodb/README.md
@@ -60,7 +60,8 @@ conversation_config = DynamoDBConversationConfig(
     table_name="Mem0Conversations",
     region="us-east-1",
     ttl_enabled=True,
-    ttl_days=30
+    ttl_days=30,
+    history_size=50
 )
 
 # Configure DynamoDB for graph database

--- a/mem0/dynamodb/config.py
+++ b/mem0/dynamodb/config.py
@@ -23,6 +23,7 @@ class DynamoDBConversationConfig(DynamoDBConfig):
     ttl_enabled: bool = Field(default=False, description="Enable TTL for conversations")
     ttl_attribute: str = Field(default="expiration_time", description="TTL attribute name")
     ttl_days: int = Field(default=30, description="Number of days until conversation expiration")
+    history_size: int = Field(default=None, description="Number of messages to keep in conversation history")
 
 
 class DynamoDBGraphConfig(DynamoDBConfig):


### PR DESCRIPTION
…00KB limit

## Description

Hey, 
Added message_size to cap the number of messages stored in a conversation, similar to what is done with LangChain.


## Type of change

Added `message_size` to the conversation config.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [X] Unit Test
- [ ] Test Script (please provide)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
